### PR TITLE
[fix] navigation url from request-lifecycle to wpgraphql-request-life…

### DIFF
--- a/docs/docs_nav.json
+++ b/docs/docs_nav.json
@@ -112,7 +112,7 @@
     },
     {
       "title": "Mutations",
-      "href": "/docs/mutations"
+      "href": "/docs/wpgraphql-mutations"
     },
     {
       "title": "Performance",

--- a/docs/docs_nav.json
+++ b/docs/docs_nav.json
@@ -96,7 +96,7 @@
     },
     {
       "title": "WPGraphQL Request Lifecycle",
-      "href": "/docs/request-lifecycle"
+      "href": "/docs/wpgraphql-request-lifecycle"
     },
     {
       "title": "Default Types and Fields",


### PR DESCRIPTION
<img width="634" alt="image" src="https://user-images.githubusercontent.com/109935474/215313521-9ca939df-814d-4ce8-91e2-95a4bcf6e9db.png">

Here is not working due to wrong url.


What does this implement/fix? Explain your changes.
---------------------------------------------------
I just changed a docs_nav file.

Does this close any currently open issues?
------------------------------------------
…
No.

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
I think I fixed sideeffect of this pr.
https://github.com/wp-graphql/wp-graphql/pull/2583


Any other comments?
-------------------
I am reading this docs, and I found some typo like this.
I would like to fix this, but I can't find some docs. could you tell me where is it? I also open discussion to ask ( https://github.com/wp-graphql/wp-graphql/discussions/2700 )
)


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
